### PR TITLE
fix log inconsistency

### DIFF
--- a/niedoida/src/do_el_stat_prop.cpp
+++ b/niedoida/src/do_el_stat_prop.cpp
@@ -439,7 +439,7 @@ namespace niedoida {
                 values.value_electron().memptr(), 3u, n_atoms);
             io::Log::instance().write(
                 io::Logger::TERSE,
-                "atomic_partial_lowdin_dipoles (in std-frame) [total, "
+                "atomic-partial-lowdin-dipoles (in std-frame) [total, "
                 "electrons contribution]",
                 value_electrons,
                 mfi_p());


### PR DESCRIPTION
Fix log inconsistency (that causes inconveniences while parsing niedoida log files).