### PR TITLE
Snaminm/fix compilation warnings

### DIFF
--- a/io_kit/src/simple_logger.cpp
+++ b/io_kit/src/simple_logger.cpp
@@ -17,6 +17,7 @@ extern "C" {
 namespace niedoida {
     namespace io {
         SimpleLogger::SimpleLogger(std::ostream& os, const std::string& s) :
+            _vl(io::Logger::TERSE),
             _os(os),
             _s(s)
         {

--- a/niedoida/include/niedoida/input_data_yaml_conversions.hpp
+++ b/niedoida/include/niedoida/input_data_yaml_conversions.hpp
@@ -102,7 +102,7 @@ namespace YAML {
 	    try {
 	      for( std::size_t i = 0; i < s; ++i )
 		v( i ) = n[i].as<double>();
-	    } catch (YAML::BadConversion) {
+	    } catch (YAML::BadConversion&) {
 	      return false;
 	    }
             return true;
@@ -146,9 +146,9 @@ namespace YAML {
 	      if ( pos != z_token.size())
 		return false;
 	      return true;
-	    } catch (std::invalid_argument) {
+	    } catch (std::invalid_argument&) {
 	      return false;
-	    } catch (std::out_of_range) {
+	    } catch (std::out_of_range&) {
 	      return false;
 	    }
         }
@@ -185,9 +185,9 @@ namespace YAML {
 	      if ( pos != charge_token.size())
 		return false;
 	      return true;
-	    } catch (std::invalid_argument) {
+	    } catch (std::invalid_argument&) {
 	      return false;
-	    } catch (std::out_of_range) {
+	    } catch (std::out_of_range&) {
 	      return false;
 	    }
         }
@@ -273,7 +273,7 @@ namespace YAML {
 	  try {
 	    v = n.as<double>();
             return true;
-	  } catch (YAML::BadConversion) {
+	  } catch (YAML::BadConversion&) {
 	    return false;
 	  }
         }

--- a/posthf_kit/src/naive_mp2.cpp
+++ b/posthf_kit/src/naive_mp2.cpp
@@ -58,7 +58,7 @@ namespace niedoida {
             try {
                 m_gmo = arma::zeros<arma::vec>(no_occ * (no_occ + 1) * no_virt *
                                                no_virt / 2);
-            } catch (std::bad_alloc) {
+            } catch (std::bad_alloc&) {
                 throw std::runtime_error("Not enough memory to make in-memory "
                                          "integral transformation");
             }
@@ -389,7 +389,7 @@ namespace niedoida {
             try {
                 m_gmo =
                     arma::zeros<arma::vec>(no_occ * no_occ * no_virt * no_virt);
-            } catch (std::bad_alloc) {
+            } catch (std::bad_alloc&) {
                 throw std::runtime_error("Not enough memory to make in-memory "
                                          "integral transformation");
             }

--- a/posthf_kit/src/rhf_mp2.cpp
+++ b/posthf_kit/src/rhf_mp2.cpp
@@ -51,7 +51,7 @@ namespace niedoida {
             try {
                 m_T1.resize(boost::extents[m_n][m_n * (m_n + 1) / 2]
                                           [m_no_occ_in_full_pass]);
-            } catch (std::bad_alloc) {
+            } catch (std::bad_alloc&) {
                 throw std::runtime_error(
                     "Not enough memory to make integral transformation.");
             }

--- a/posthf_kit/src/rhf_mp2_imp.cpp
+++ b/posthf_kit/src/rhf_mp2_imp.cpp
@@ -159,7 +159,7 @@ namespace niedoida {
             try {
                 m_T_2.resize(
                     boost::extents[m_n][m_n][m_no_occ][m_no_occ_in_full_pass]);
-            } catch (std::bad_alloc) {
+            } catch (std::bad_alloc&) {
                 throw std::runtime_error(
                     "Not enough memory to make integral transformation.");
             }

--- a/posthf_kit/src/rhf_mp2_minmem.cpp
+++ b/posthf_kit/src/rhf_mp2_minmem.cpp
@@ -449,7 +449,7 @@ namespace niedoida {
             try {
                 m_I.resize(boost::extents[m_n][m_n][m_no_pairs_in_full_pass]);
                 m_P.resize(boost::extents[m_n][m_n][m_no_pairs_in_full_pass]);
-            } catch (std::bad_alloc) {
+            } catch (std::bad_alloc&) {
                 throw std::runtime_error(
                     "Not enough memory to make integral transformation.");
             }

--- a/yaml_inputter/include/yaml_inputter/templated_fetcher_functions.hpp
+++ b/yaml_inputter/include/yaml_inputter/templated_fetcher_functions.hpp
@@ -93,7 +93,7 @@ namespace yaml_inputter {
             try {
                 Value_t val = result.value.template as<Value_t>();
                 return {val, result.name, result.problem};
-            } catch (YAML::BadConversion) {
+            } catch (YAML::BadConversion&) {
                 Problem problem;
                 problem.no = Errno::fetched_conversion_fail;
                 problem.message = "[PROBLEM] yaml-bad-conversion error.";
@@ -113,7 +113,7 @@ namespace yaml_inputter {
             try {
                 Value_t val = result.value.template as<Value_t>();
                 return {val, result.name, result.problem};
-            } catch (YAML::BadConversion) {
+            } catch (YAML::BadConversion&) {
                 Problem problem;
                 problem.no = Errno::fetched_conversion_fail;
                 problem.message = "[PROBLEM] yaml-bad-conversion error.";


### PR DESCRIPTION
(1) fix Wcatch-value compile warnings.
(2) fix valgrind’s “Conditional jump or move depends on uninitialised value(s)” error when logger is used before the user requested verbosity level was set.